### PR TITLE
ログ出力周りを整理

### DIFF
--- a/api_server/Dockerfile
+++ b/api_server/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.6
 
-ENV APP_DIR /usr/src/app
+ENV APP_DIR=/usr/src/app \
+  STDOUT_SYNC=true
 
 WORKDIR $APP_DIR
 

--- a/api_server/config/boot.rb
+++ b/api_server/config/boot.rb
@@ -2,3 +2,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+
+if ENV['STDOUT_SYNC'] == 'true'
+  STDOUT.sync = true
+end

--- a/api_server/config/environments/production.rb
+++ b/api_server/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## やったこと
* RAILS_ENV=produciton のときの Log level を :info に変更する
* Docker コンテナ上からの出力をバッファに溜め込まないようにする