### PR TITLE
カウンターの送信を非同期にする

### DIFF
--- a/api_server/Gemfile
+++ b/api_server/Gemfile
@@ -15,6 +15,8 @@ gem 'redis-objects'
 gem 'hiredis'
 gem 'redis-namespace'
 gem 'connection_pool'
+gem 'sidekiq'
+gem 'sidekiq-scheduler'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/api_server/Gemfile.lock
+++ b/api_server/Gemfile.lock
@@ -65,7 +65,12 @@ GEM
     crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.9.0)
+    et-orbi (1.2.2)
+      tzinfo
     ffi (1.11.1)
+    fugit (1.3.3)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hiredis (0.6.3)
@@ -93,7 +98,10 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     puma (3.12.1)
+    raabro (1.1.6)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.0)
@@ -149,6 +157,18 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
     ruby_dep (1.5.0)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    sidekiq-scheduler (3.0.0)
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      tilt (>= 1.4.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -162,6 +182,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.10)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     websocket-driver (0.7.1)
@@ -185,6 +206,8 @@ DEPENDENCIES
   redis-namespace
   redis-objects
   rspec-rails
+  sidekiq
+  sidekiq-scheduler
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/api_server/app/channels/counter_channel.rb
+++ b/api_server/app/channels/counter_channel.rb
@@ -9,7 +9,8 @@ class CounterChannel < ApplicationCable::Channel
   end
 
   def increment(data)
-    value = Counter.increment(data['count'])
-    self.class.broadcast_to('default', from: data['identifier'], count: value)
+    Counter.lock! do
+      Counter.increment(data['identifier'], data['count'])
+    end
   end
 end

--- a/api_server/app/jobs/counter_broadcasting_job.rb
+++ b/api_server/app/jobs/counter_broadcasting_job.rb
@@ -1,0 +1,14 @@
+class CounterBroadcastingJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return unless Counter.buffer.present?
+    Counter.lock! do
+      CounterChannel.broadcast_to('default', {
+        count: Counter.count,
+        buffer: Counter.buffer,
+      })
+      Counter.reset_buffer!
+    end
+  end
+end

--- a/api_server/app/models/counter.rb
+++ b/api_server/app/models/counter.rb
@@ -2,18 +2,35 @@ class Counter
   include Redis::Objects
 
   counter :count
+  hash_key :buffer
+  lock :counter
 
   class << self
     def counter
       @counter ||= new
     end
 
-    def increment(count = 1)
+    def increment(identifier, count = 1)
       counter.count.increment(count)
+      counter.buffer.incrby(identifier, count)
     end
 
     def count
       counter.count.value
+    end
+
+    def buffer
+      counter.buffer.value
+    end
+
+    def reset_buffer!
+      counter.redis.del(counter.buffer.key)
+    end
+
+    def lock!
+      counter.counter_lock.lock do
+        yield
+      end
     end
   end
 

--- a/api_server/config/environments/development.rb
+++ b/api_server/config/environments/development.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  config.active_job.queue_adapter = :sidekiq
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true

--- a/api_server/config/environments/production.rb
+++ b/api_server/config/environments/production.rb
@@ -73,6 +73,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.active_job.queue_adapter = :sidekiq
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/api_server/config/sidekiq.yml
+++ b/api_server/config/sidekiq.yml
@@ -1,3 +1,3 @@
 :schedule:
   CounterBroadcastingJob:
-    every: 5s
+    every: 3s

--- a/api_server/config/sidekiq.yml
+++ b/api_server/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:schedule:
+  CounterBroadcastingJob:
+    every: 5s

--- a/api_server/spec/jobs/counter_broadcasting_job_spec.rb
+++ b/api_server/spec/jobs/counter_broadcasting_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CounterBroadcastingJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       - 13000:3000
     volumes:
       - ./api_server:/usr/src/app
+  api_server_sidekiq:
+    image: youwatana.be/api_server
+    build:
+      context: ./api_server
+    env_file: ./api_server/.env
+    volumes:
+      - ./api_server:/usr/src/app
+    command: bundle exec sidekiq
   frontend:
     image: youwatana.be/frontend
     build:

--- a/frontend/components/counter.vue
+++ b/frontend/components/counter.vue
@@ -31,11 +31,14 @@ export default {
   data() {
     return {
       disconnected: true,
-      identifier: null,
-      count: 0,
-      temporaryCount: 0,
-      tweenedNumber: 0,
       playerNotReady: true,
+      identifier: null,
+      count: {
+        serverCount: 0,
+        notSendCount: 0,
+        serverSentCount: 0,
+      },
+      tweenedNumber: 0,
     }
   },
   async created() {
@@ -48,7 +51,7 @@ export default {
       disconnected: (data) => { this.$data.disconnected = true },
     })
 
-    this.intervalObject = setInterval(this.sendTemporaryCount, 1000)
+    this.intervalObject = setInterval(this.sendLocalCount, 1000)
   },
   beforeDestroy() {
     this.counterChannel.unsubscribe()
@@ -58,27 +61,33 @@ export default {
     animatedCounter() {
       return this.$data.tweenedNumber.toFixed(0)
     },
+    displayCount() {
+      return this.$data.count.serverCount + this.localCount
+    },
     localCount() {
-      return this.$data.count + this.$data.temporaryCount
+      return this.$data.count.serverSentCount + this.$data.count.notSendCount
     }
   },
   methods: {
     handleClick() {
-      this.$data.temporaryCount++
+      this.$data.count.notSendCount++
       this.$refs.soundPlayer.playSound()
     },
-    sendTemporaryCount() {
-      if (this.$data.temporaryCount > 0) {
+    sendLocalCount() {
+      if (this.$data.count.notSendCount > 0) {
         this.counterChannel.perform('increment', {
-          count: this.$data.temporaryCount, identifier: this.$data.identifier
+          identifier: this.$data.identifier, count: this.$data.count.notSendCount
         })
+        this.$data.count.serverSentCount += this.$data.count.notSendCount
+        this.$data.count.notSendCount = 0
       }
     },
     receivedCount(receivedData) {
-      this.$data.count = receivedData['count']
+      const countDiff = receivedData['count'] - this.$data.count.serverCount
+      this.$data.count.serverCount = receivedData['count']
 
-      if (this.$data.identifier == receivedData['from']) {
-        this.$data.temporaryCount = 0
+      if (this.$data.identifier === receivedData['from']) {
+        this.$data.count.serverSentCount -= countDiff
       }
     },
     async getIdentifier() {
@@ -94,7 +103,7 @@ export default {
     }
   },
   watch: {
-    localCount(newValue) {
+    displayCount(newValue) {
       TweenLite.to(this.$data, 0.5, { tweenedNumber: newValue })
     },
   }

--- a/frontend/components/counter.vue
+++ b/frontend/components/counter.vue
@@ -83,11 +83,10 @@ export default {
       }
     },
     receivedCount(receivedData) {
-      const countDiff = receivedData['count'] - this.$data.count.serverCount
       this.$data.count.serverCount = receivedData['count']
 
-      if (this.$data.identifier === receivedData['from']) {
-        this.$data.count.serverSentCount -= countDiff
+      if ('buffer' in receivedData && this.$data.identifier in receivedData['buffer']) {
+        this.$data.count.serverSentCount -= receivedData['buffer'][this.$data.identifier]
       }
     },
     async getIdentifier() {

--- a/frontend/components/counter.vue
+++ b/frontend/components/counter.vue
@@ -42,7 +42,8 @@ export default {
     }
   },
   async created() {
-    this.getIdentifier()
+    await this.getIdentifier()
+
     const channel = actioncable.createConsumer('ws://localhost:13000/cable')
     this.counterChannel = channel.subscriptions.create('CounterChannel', {
       connected: () => { this.$data.disconnected = false },


### PR DESCRIPTION
resolved: #9 

## やったこと
* ローカルのカウント数が1秒間サーバー側から返ってこなかった場合に同じ値を送信し続けてしまうバグの修正
* カウンターのカウントアップした人をサーバー側で保持できるようにバッファを実装する（これバッファというのか？）
* Sidekiqで非同期的にブロードキャストする